### PR TITLE
add hover popups to network graph edges

### DIFF
--- a/src/utils/graph_vis.py
+++ b/src/utils/graph_vis.py
@@ -243,3 +243,5 @@ class Edge(object):
         if directed:
             if "arrows" not in self.options:
                 self.options["arrows"] = "to"
+        if "label" in self.options:
+            self.options["title"] = self.options["label"]


### PR DESCRIPTION
# What is changed?
In the network graph, edges now have hover popups similar to nodes, which show the same number as the edge label (for the cases where the edge label is hard to read)

# Checklist
- [x] Unit tests pass
- [ ] New logic / functionality tests added
- [ ] TODO list updated / cleaned up  
- [x] Manually tested main workflows (login, search, cell details, stats) 
- [x] Linter applied
- [ ] Integration tests pass (Optional)

Thank you for contributing :heart:
