### PR TITLE
Use cross-platform command to open web browser

### DIFF
--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,4 +1,4 @@
-open http://localhost:5000/ && \
+python -m webbrowser -t http://localhost:5000/ && \
 export FLASK_APP=src.main && \
 export FLASK_SECRET_KEY=dev_dummy_key && \
 export SMOKE_TEST_KEY=dev_smoke_test_key && \


### PR DESCRIPTION
uses the python standard module webbrowser: https://docs.python.org/3/library/webbrowser.html  which works cross-platform, instead of open which only works on mac

# What is changed?

# Checklist
- [x] Unit tests pass
- [ ] New logic / functionality tests added
- [ ] TODO list updated / cleaned up  
- [ ] Manually tested main workflows (login, search, cell details, stats) 
- [ ] Linter applied
- [ ] Integration tests pass (Optional)

Thank you for contributing :heart:
