### PR TITLE
Animate thumbnails on hover entire row

### DIFF
--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -31,6 +31,22 @@
         input_box.form.submit();
         input_box.value = old_val;
     }
+
+    const skeletonThumbnailUrls = {{skeleton_thumbnail_urls|tojson}};
+
+    function hover_row(rowElem, rootID) {
+        const newSrc = skeletonThumbnailUrls[rootID][1];
+        if (rowElem.querySelector(".skeleton_thumbnail").src !== newSrc) {
+            rowElem.querySelector(".skeleton_thumbnail").src = newSrc;
+        }
+    }
+
+    function unhover_row(rowElem, rootID) {
+        const newSrc = skeletonThumbnailUrls[rootID][0];
+        if (rowElem.querySelector(".skeleton_thumbnail").src !== newSrc) {
+            rowElem.querySelector(".skeleton_thumbnail").src = newSrc;
+        }
+    }
 </script>
 
 
@@ -53,12 +69,12 @@
         </thead>
         <tbody>
         {% for neuron in display_data %}
-        <tr>
+        <tr onmouseover="hover_row(this, '{{neuron.root_id}}');"
+            onmouseleave="unhover_row(this, '{{neuron.root_id}}');">
             <td style="padding: 0px; margin: 0px;" ><a
                     href="{{url_for('app.cell_details', data_version=data_version, root_id=neuron.root_id)}}" onclick="loading(event);"><img
+                    class="skeleton_thumbnail"
                     src="{{skeleton_thumbnail_urls.get(neuron.root_id)[0]}}"
-                    onmouseover="this.src='{{skeleton_thumbnail_urls.get(neuron.root_id)[1]}}'"
-                    onmouseout="this.src='{{skeleton_thumbnail_urls.get(neuron.root_id)[0]}}'"
                     width="200px" height="150px;" border="1px;"></a></td>
             <td><a href="{{url_for('app.cell_details', data_version=data_version, root_id=neuron.root_id)}}" onclick="loading(event);">{{neuron.name}}</a><br><small>{{neuron.root_id}}</small>
             </td>


### PR DESCRIPTION
# What is changed?
Switch to animated skeleton thumbnails when hovering anywhere on the cell row, not just the image.

# Checklist
- [x] Unit tests pass
- [ ] New logic / functionality tests added
- [ ] TODO list updated / cleaned up  
- [x] Manually tested main workflows (login, search, cell details, stats) 
- [x] Linter applied
- [ ] Integration tests pass (Optional)

Thank you for contributing :heart:
