### PR TITLE
Make "open in flywire" link open in actual flywire

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ gunicorn==20.1.0
 requests==2.28.1
 google-auth==2.11.0
 user-agents==2.2.0
+nglui>=2.7.2
+caveclient==4.20.2

--- a/src/service/cell_details.py
+++ b/src/service/cell_details.py
@@ -27,9 +27,12 @@ def cached_cell_details(
             ]
         )
     )
+    pos = (
+        nanometer_to_flywire_coordinates(nd["position"][0]) if nd["position"] else None
+    )
     cell_attributes = {
         "Name": nd["name"],
-        "FlyWire Root ID": f'{root_id}<br><small><a href="{nglui.url_for_root_ids([root_id], version=data_version, point_to_proofreading_flywire=True)}">Open in FlyWire <i class="fa-solid fa-up-right-from-square"></i> </a></small>',
+        "FlyWire Root ID": f'{root_id}<br><small><a href="{nglui.url_for_root_ids([root_id], version=data_version, point_to_proofreading_flywire=True, position=pos)}" target="_blank">Open in FlyWire <i class="fa-solid fa-up-right-from-square"></i> </a></small>',
         "Partners<br><small>Synapses</small>": "{:,}".format(nd["input_cells"])
         + " in, "
         + "{:,}".format(nd["output_cells"])


### PR DESCRIPTION
# What is changed?
Previously "open in flywire" button on cell details page opened it in Neuroglancer, now it opens in Flywire (and properly centers the cell).

# Checklist
- [x] Unit tests pass
- [ ] New logic / functionality tests added
- [ ] TODO list updated / cleaned up  
- [x] Manually tested main workflows (login, search, cell details, stats) 
- [x] Linter applied
- [ ] Integration tests pass (Optional)

Thank you for contributing :heart:
