### PR TITLE
show full traceback instead of error page in dev

### DIFF
--- a/src/blueprints/base.py
+++ b/src/blueprints/base.py
@@ -118,7 +118,10 @@ def request_wrapper(func):
             traceback.print_exc()
             log_error(f"Exception when executing {signature}: {e}")
             num_request_errors += 1
-            return render_error(f"{e}\n")
+            if APP_ENVIRONMENT == "DEV":
+                raise e
+            else:
+                return render_error(f"{e}\n")
 
     return wrap
 


### PR DESCRIPTION
# What is changed?
The error page we have is suitable for production, but can be frustrating in development as it hides really useful traceback information provided by flask. This is still available in the logs, but it's often annoying to go and find it. 

Additionally, Flask supports _interactive_ debugging right from the traceback page, so you can drop in, inspect variables, etc. 

Before:
<img width="945" alt="Screenshot 2023-02-22 at 11 21 08 AM" src="https://user-images.githubusercontent.com/4590343/220689685-86efc29e-e13d-4729-a83c-509b0357d6ce.png">

After: (in development only)
<img width="957" alt="Screenshot 2023-02-22 at 11 21 41 AM" src="https://user-images.githubusercontent.com/4590343/220689711-c9791045-b3e0-4739-b85b-0ebffcebe679.png">


# Checklist
- [ ] Unit tests pass
- [ ] New logic / functionality tests added
- [ ] TODO list updated / cleaned up  
- [ ] Manually tested main workflows (login, search, cell details, stats) 
- [ ] Linter applied
- [ ] Integration tests pass (Optional)

Thank you for contributing :heart:
