### PR TITLE
Reduce overlap of network graph nodes

### DIFF
--- a/src/templates/network_graph.html
+++ b/src/templates/network_graph.html
@@ -325,6 +325,10 @@
                     "iterations": 1000,
                     "onlyDynamicEdges": false,
                     "updateInterval": 50
+                },
+                "barnesHut": {
+                    "gravitationalConstant": -1000,
+                    "centralGravity": 1
                 }
             }
         };
@@ -413,6 +417,12 @@
 
         network.on("release", function (params) {
             network.selectNodes([]);
+        });
+
+        network.on("stabilizationIterationsDone", function () {
+            network.setOptions({
+                physics: false
+            });
         });
 
         return network;

--- a/src/utils/graph_vis.py
+++ b/src/utils/graph_vis.py
@@ -327,7 +327,7 @@ def make_graph_html(
 
 class Network(object):
     def __init__(
-        self, show_edge_weights, edge_physics=True, node_physics=False, layers=None
+        self, show_edge_weights, edge_physics=True, node_physics=True, layers=None
     ):
         self.edges = []
         self.node_map = {}


### PR DESCRIPTION
# What is changed?
Re-enable node physics by default to improve graph layouts and reduce overlap. Then disable physics after the layout finishes so nodes don't keep sliding around when repositioned by the user.

# Checklist
- [x] Unit tests pass
- [ ] New logic / functionality tests added
- [ ] TODO list updated / cleaned up  
- [x] Manually tested main workflows (login, search, cell details, stats) 
- [x] Linter applied
- [ ] Integration tests pass (Optional)

Thank you for contributing :heart:
