### PR TITLE
Show loading spinner for network graph

### DIFF
--- a/src/templates/network_graph.html
+++ b/src/templates/network_graph.html
@@ -444,9 +444,9 @@
     }, false);
 
     const ctx = canvas.getContext("2d");
-    ctx.font = "48px sans-serif";
+    ctx.font = "24px sans-serif";
     ctx.textAlign = "center";
-    ctx.fillText("Rendering...", canvas.width / 2, canvas.height / 2);
+    ctx.fillText("Rendering...", window.innerWidth / 2, window.innerHeight / 2);
 </script>
 </body>
 </html>


### PR DESCRIPTION
# What is changed?
While loading/rendering the network graph page (which can take significant time due to physics layout), activate the Codex loading spinner, and disable it once the layout is finished.

# Checklist
- [x] Unit tests pass
- [ ] New logic / functionality tests added
- [ ] TODO list updated / cleaned up  
- [x] Manually tested main workflows (login, search, cell details, stats) 
- [x] Linter applied
- [ ] Integration tests pass (Optional)

Thank you for contributing :heart:
